### PR TITLE
Add support for submeshing

### DIFF
--- a/plug-ins/format.json
+++ b/plug-ins/format.json
@@ -1,0 +1,45 @@
+{
+  meshes: [
+    faces: {
+      // indexed by material
+      "0": {
+        quads: [1, 2, 3, 4],
+        triangles: [1, 2, 3]
+      }
+    }
+    materials: [
+      {
+        // same as three
+      }
+    ]
+    vertices: [1.0, 0.5, 0.0, 2.0, 1.0, 0.0],
+    normals: [1.0, 0.5, 0.0, 2.0, 1.0, 0.0],
+    uvs: [0.0, 1.0],
+    skinWeights: [0.0, 0.0, 1.0, 0.0],
+    skinIndices: [0, 1, 2, 3, 4, 5]
+  ],
+
+  joints: [
+    {
+      // same as three
+    }
+  ],
+
+  animations: [
+    {
+      "name": "foo",
+      "length": 1.24,
+      "timeline": [
+        // same indexes as joints
+        [
+          {
+            "time": 0.0,
+            "rotation": [/*...*/],
+            "translation": [/*...*/],
+            "scale": [/*...*/]
+          }
+        ]
+      ]
+    }
+  ]
+}

--- a/scripts/ThreeJsExportScript.mel
+++ b/scripts/ThreeJsExportScript.mel
@@ -31,7 +31,9 @@ global proc int ThreeJsExportScript(string $parent, string $action, string $sett
               checkBox -v true -l "Material Indices" materialsCb;
               checkBox -v true -l "Diffuse Maps" diffuseMapsCb;
               checkBox -v true -l "Specular Maps" specularMapsCb;
+              checkBox -v true -l "Gloss Maps" glossMapsCb;
               checkBox -v true -l "Bump Maps" bumpMapsCb;
+              checkBox -v true -l "Incandescence Masks" incandescenceCb;
               checkBox -v true -l "Copy Texture Files to Target Directory" copyTexturesCb;
               setParent ..; // columnLayout
             setParent ..; // frameLayout
@@ -39,12 +41,6 @@ global proc int ThreeJsExportScript(string $parent, string $action, string $sett
           frameLayout -cll true -cl false -bv true -bs "etchedIn" -l "Animation Options";
             columnLayout -adj true;
               checkBox -v true -l "Export Animations" animCb;
-              checkBox
-                -v false
-                -l "Bake Animation"
-                -onc "textField -e -en true startText; textField -e -en true endText; textField -e -en true stepText;"
-                -ofc "textField -e -en false startText; textField -e -en false endText; textField -e -en false stepText;"
-                bakeAnimCb;
               textField -en false -tx `playbackOptions -minTime true -q` -ann "Start" startText;
               textField -en false -tx `playbackOptions -maxTime true -q` -ann "End" endText;
               textField -en false -tx 1 -ann "Step" stepText;
@@ -75,8 +71,12 @@ global proc int ThreeJsExportScript(string $parent, string $action, string $sett
             $option += "diffuseMaps ";
         if (`checkBox -q -v specularMapsCb`)
             $option += "specularMaps ";
+        if (`checkBox -q -v glossMapsCb`)
+            $option += "glossMaps ";
         if (`checkBox -q -v bumpMapsCb`)
             $option += "bumpMaps ";
+        if (`checkBox -q -v incandescenceCb`)
+            $option += "incandescenceMasks ";
         if (`checkBox -q -v copyTexturesCb`)
             $option += "copyTexturesMaps ";
         if (`checkBox -q -v colorsCb`)
@@ -89,16 +89,6 @@ global proc int ThreeJsExportScript(string $parent, string $action, string $sett
         }
         if (`checkBox -q -v animCb`)
             $option += "skeletalAnim ";
-        if (`checkBox -q -v bakeAnimCb`)
-        {
-            $option += "bakeAnimations ";
-            $option += `textField -q -tx startText`;
-            $option += " ";
-            $option += `textField -q -tx endText`;
-            $option += " ";
-            $option += `textField -q -tx stepText`;
-            $option += " ";
-        }
         if (`checkBox -q -v prettyOutputCb`)
             $option += "prettyOutput ";
         $option += "\"";


### PR DESCRIPTION
The scene is no longer assumed to be a single mesh. The keys `vertices`,
`uvs`, `normals`, `faces`, `skinWeights`, and `skinIndices` have all
been moved to a separate array of objects under the key `meshes`. The
`bakeAnimations` option was also supported as it is unused by the
current engines/file formats
